### PR TITLE
Fix PHP-FPM Concurrency Issue

### DIFF
--- a/ubuntu/99-sysctl.conf
+++ b/ubuntu/99-sysctl.conf
@@ -30,3 +30,6 @@ net.ipv6.conf.all.accept_ra = 2
 
 ## avoid Redis warnings
 vm.overcommit_memory = 1
+
+## override default 128 max connections for PHP-FPM Socket
+net.core.somaxconn = 4096


### PR DESCRIPTION
Using apache bench, I was able to hit the 128 connection default limit for a domain socket pretty easily.